### PR TITLE
binaries: update agent version

### DIFF
--- a/docs/binaries.md
+++ b/docs/binaries.md
@@ -20,7 +20,7 @@ Download the relevant binaries (`deb` or artifacts) using the links in the
 Component     | Version |  Package | Binary Artifact
 ------------- | --------| -------- | -------------
 vAccelRT core | v0.5.0  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/x86_64/Release-deb/vaccel-0.5.0-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/aarch64/Release-deb/vaccel-0.5.0-Linux.deb) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/armv7l/Release-deb/vaccel-0.5.0-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/x86_64/Release-tar/vaccel-0.5.0-Linux.tar.gz) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/aarch64/Release-tar/vaccel-0.5.0-Linux.tar.gz) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/main/armv7l/Release-tar/vaccel-0.5.0-Linux.tar.gz)
-vAccelRT agent  | v0.3.5  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.5-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/aarch64/Release-deb/vaccelrt-agent-0.3.5-Linux.deb) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/armv7l/Release-deb/vaccelrt-agent-0.3.5-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release/vaccelrt-agent) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/aarch64/Release/vaccelrt-agent) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/armv7l/Release/vaccelrt-agent)
+vAccelRT agent  | v0.3.6  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.6-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/aarch64/Release-deb/vaccelrt-agent-0.3.6-Linux.deb) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/armv7l/Release-deb/vaccelrt-agent-0.3.6-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release/vaccelrt-agent) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/aarch64/Release/vaccelrt-agent) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/armv7l/Release/vaccelrt-agent)
 Jetson plugin | v0.1.0  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/jetson_inference/main/x86_64/Release-deb/vaccelrt-plugin-jetson-0.1.0-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/jetson_inference/main/aarch64/Release-deb/vaccelrt-plugin-jetson-0.1.0-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/jetson_inference/main/x86_64/Release/libvaccel-jetson.so) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/jetson_inference/main/aarch64/Release/libvaccel-jetson.so)
 Tensorflow plugin | v0.1.0  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/tensorflow/main/x86_64/Release-deb/vaccelrt-plugin-tf-0.1.0-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/tensorflow/main/aarch64/Release-deb/vaccelrt-plugin-tf-0.1.0-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/tensorflow/main/x86_64/Release/libvaccel-tf.so) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/tensorflow/main/aarch64/Release/libvaccel-tf.so)
 PYNQ plugin   | v0.1.1  | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/x86_64/Release-deb/vaccelrt-plugin-pynq-0.1.1-Linux.deb) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/aarch64/Release-deb/vaccelrt-plugin-pynq-0.1.1-Linux.deb) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/armv7l/Release-deb/vaccelrt-plugin-pynq-0.1-Linux.deb) | [`x86_64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/x86_64/Release/libvaccel-pynq.so) [`arm64`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/aarch64/Release/libvaccel-pynq.so) [`arm`](https://s3.nbfc.io/nbfc-assets/github/vaccelrt/plugins/pynq/main/armv7l/Release/libvaccel-pynq.so)
@@ -224,31 +224,31 @@ To install the agent, download the relevant `deb` package for the host
 architecture and install it. 
 
 ```bash
-wget https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.5-Linux.deb
-dpkg -i vaccelrt-agent-0.3.5-Linux.deb
+wget https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.6-Linux.deb
+dpkg -i vaccelrt-agent-0.3.6-Linux.deb
 ```
 
 The output should be something like the following:
 
 ```console
-# wget https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.5-Linux.deb
---2022-11-10 18:20:57--  https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.5-Linux.deb
+# wget https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.6-Linux.deb
+--2022-11-10 18:20:57--  https://s3.nbfc.io/nbfc-assets/github/vaccelrt/agent/main/x86_64/Release-deb/vaccelrt-agent-0.3.6-Linux.deb
 Resolving s3.nbfc.io (s3.nbfc.io)... 84.254.1.240
 Connecting to s3.nbfc.io (s3.nbfc.io)|84.254.1.240|:443... connected.
 HTTP request sent, awaiting response... 200 OK
 Length: 1738158 (1.7M) [application/x-debian-package]
-Saving to: 'vaccelrt-agent-0.3.5-Linux.deb'
+Saving to: 'vaccelrt-agent-0.3.6-Linux.deb'
 
-vaccelrt-agent-0.3.5-Linux.deb       100%[=====================================================================>]   1.66M  --.-KB/s    in 0.06s
+vaccelrt-agent-0.3.6-Linux.deb       100%[=====================================================================>]   1.66M  --.-KB/s    in 0.06s
 
-2022-11-10 18:20:58 (25.8 MB/s) - 'vaccelrt-agent-0.3.5-Linux.deb' saved [1738158/1738158]
+2022-11-10 18:20:58 (25.8 MB/s) - 'vaccelrt-agent-0.3.6-Linux.deb' saved [1738158/1738158]
 
-root@18c0e0189e2b:/# dpkg -i vaccelrt-agent-0.3.5-Linux.deb
+root@18c0e0189e2b:/# dpkg -i vaccelrt-agent-0.3.6-Linux.deb
 Selecting previously unselected package vaccelrt-agent.
 (Reading database ... 4878 files and directories currently installed.)
-Preparing to unpack vaccelrt-agent-0.3.5-Linux.deb ...
-Unpacking vaccelrt-agent (0.3.5) ...
-Setting up vaccelrt-agent (0.3.5) ...
+Preparing to unpack vaccelrt-agent-0.3.6-Linux.deb ...
+Unpacking vaccelrt-agent (0.3.6) ...
+Setting up vaccelrt-agent (0.3.6) ...
 ```
 
 and you should see the binary in `/usr/local/bin`:


### PR DESCRIPTION
update link to binary link of the agent for all architectures, to reflect our latest version