### PR TITLE
ci: Make docs versioned

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -37,17 +37,25 @@ jobs:
           submodules: 'false'
           remote-actions-repo: ${{ inputs.actions-repo }}
           token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+          fetch-depth: 0
 
       - name: Install requirements
         run: sudo pip install -r requirements.txt
 
-      - name: Build mkdocs site
+      - name: Verify build with mkdocs
         run: mkdocs build
 
       - name: Deploy to Github Pages
         if: ${{ inputs.deploy == true }}
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: ./site
-          git-config-name: 'github-actions[bot]'
-          git-config-email: '41898282+github-actions[bot]@users.noreply.github.com'
+        run: |
+          git config --global \
+            user.name "github-actions[bot]"
+          git config --global \
+            user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest
+          else
+            mike deploy --push --update-aliases main dev
+          fi
+        shell: bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,18 +73,10 @@ theme:
 #        accent: indigo
  
 
-#extra:
-#  logo: img/vaccel-logo.png
-#  logo_title: "Rocketbank logo"
-#  include_toc: yes
-#  sidebars:
-#    - about
-#    - navigation
-#    - related
-#    - search
-#
-#  extra_nav_links:
-#    Fork me on GitHub: https://github.com/iamale/rock-cli
+extra:
+  version:
+    provider: mike
+    alias: true
 
 features:
   - navigation.instant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
 mkdocs-section-index
+mike


### PR DESCRIPTION
Use `mike` to generate versioned docs. The latest tag becomes the default version while `dev` points to HEAD.

With the updated  workflow, docs can be built as usual, while the deployment process to `gh-pages` is done via `mike`:
- We can build and view the current docs as usual, ie.:
  ```sh
  mkdocs serve
  ```
  will build and show the documentation from the current branch without any version dropdown or information
- If we want to build and view the final, versioned documentation, we can:
  - Deploy the current HEAD with `mike`:
    ```sh
    mike deploy --update-aliases main dev
    ```
    This will create a new (local) commit to the `gh-pages` branch.
  - Serve the documentation with `mike`:
     ```sh
    mike serve
    ```
    This will show the built, versioned documentation committed in the `gh-pages` branch instead of building and showing the current (source) branch (like `mkdocs serve`).

There is no need to view the versioned form of the documentation locally, the CI should correctly deploy the documentation on push to `main`. If we have to, we need to make sure that we have the latest `gh-pages` branch locally before using `mike`.
