### PR TITLE
ci: Fix verification and deployment jobs

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -44,6 +44,7 @@ runs:
           user.name "github-actions[bot]"
         git config --global \
           user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        ./.venv/bin/mike deploy --push --update-aliases \
+        source ./.venv/bin/activate
+        mike deploy --push --update-aliases \
           "${{ inputs.deploy-version }}" "${{ inputs.deploy-alias }}"
       shell: bash

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -46,7 +46,7 @@ jobs:
           app-id: ${{ vars.VACCEL_BOT_APP_ID }}
           private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          permission-contents: read
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Initialize workspace

--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -66,6 +66,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
+            --retry-wait-time 8
             --root-dir $(pwd)/site
             --exclude ^https://${{ env.SITE_URL_ESC }}
             site


### PR DESCRIPTION
Fix verification and deployment jobs:
- Fix deployment in `build-docs` action
- Increase retry time for `verify-links` to avoid hitting rate limits